### PR TITLE
Lighten layout issues with translations on event edit page

### DIFF
--- a/views/default/event_calendar/css.php
+++ b/views/default/event_calendar/css.php
@@ -175,7 +175,7 @@ li.event-calendar-filter-menu-show-only {
 
 .event-calendar-edit-form-block label {
 	float: left;
-	width: 90px;
+	width: 105px;
 	margin-top: 5px;
 }
 

--- a/views/default/forms/event_calendar/edit.php
+++ b/views/default/forms/event_calendar/edit.php
@@ -148,9 +148,9 @@ $vars['prefix'] = $prefix;
 $body .= elgg_view('event_calendar/schedule_section', $vars);
 
 if ($event_calendar_spots_display == 'yes') {
-	$body .= '<p><label>'.elgg_echo("event_calendar:spots_label").'<br />';
+	$body .= '<br><p><label>'.elgg_echo("event_calendar:spots_label").'</label>';
 	$body .= elgg_view("input/text", array('name' => 'spots', 'class' => 'event-calendar-medium-text', 'value' => $spots));
-	$body .= '</label></p>';
+	$body .= '</p>';
 	$body .= '<p class="event-calendar-description">'.$prefix['spots'].elgg_echo('event_calendar:spots_description').'</p>';
 }
 


### PR DESCRIPTION
Slightly increase of width of label column to avoid issues with label text linewraps for other languages than English. This is not necessarily the fix to avoid any linewraps but it should improve the situations at least if the translated label texts are not too long.
